### PR TITLE
Improve cleanup commands and more

### DIFF
--- a/de.capypara.FieldMonitor.json
+++ b/de.capypara.FieldMonitor.json
@@ -243,21 +243,6 @@
       ]
     },
     {
-      "name": "blueprint-compiler",
-      "buildsystem": "meson",
-      "cleanup": [
-        "*"
-      ],
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler.git",
-          "commit": "04ef0944db56ab01307a29aaa7303df6067cb3c0",
-          "tag": "v0.16.0"
-        }
-      ]
-    },
-    {
       "name": "field-monitor",
       "buildsystem": "meson",
       "config-opts": [

--- a/de.capypara.FieldMonitor.json
+++ b/de.capypara.FieldMonitor.json
@@ -27,12 +27,15 @@
   },
   "cleanup": [
     "/include",
+    "/lib/cmake",
+    "/lib/girepository-1.0",
     "/lib/pkgconfig",
-    "/man",
+    "/share/bash-completion",
     "/share/doc",
     "/share/gtk-doc",
     "/share/man",
     "/share/pkgconfig",
+    "/share/vala",
     "*.la",
     "*.a"
   ],


### PR DESCRIPTION
### Drop ineffective cleanup commands

- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size

```
16K	    ./lib/cmake
128K	./lib/girepository-1.0
8,0K	./share/bash-completion
132K	./share/vala
```

### Use the blueprint-compiler module from the runtime

Use the blueprint-compiler module from the runtime

**Please don't forget to test before merging. I don't have a remote server to test this application.**